### PR TITLE
Database Migrating w/ Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /app
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o server cmd/server/main.go
 
+RUN go run ./cmd/migrate
+
 FROM scratch
 
 COPY --from=builder /app /

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /app
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o server cmd/server/main.go
 
-RUN go run ./cmd/migrate
-
 FROM scratch
 
 COPY --from=builder /app /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine as builder
+FROM golang:1.24-alpine AS builder
 
 RUN mkdir /app
 
@@ -6,10 +6,24 @@ ADD . /app
 
 WORKDIR /app
 
+ENV DOCKERIZE_VERSION=v0.9.3
+
+RUN apk update --no-cache \
+    && apk add --no-cache wget openssl \
+    && wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin \
+    && apk del wget
+
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o server cmd/server/main.go
 
-FROM scratch
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o migrate cmd/migrate/main.go
 
+FROM alpine:3.21
+
+COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /app /
+
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]
 
 CMD ["/server"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
             - "$FIBER_APP_PORT:$FIBER_APP_PORT"
         depends_on:
             - mysql
+        networks:
+            - server
 
     mysql:
         container_name: mysql
@@ -25,3 +27,8 @@ services:
             TZ: "Asia/Seoul"
         volumes:
             - "./init.sql:/docker-entrypoint-initdb.d/init.sql"
+        networks:
+            - server
+
+networks:
+    server:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+dockerize -wait tcp://$DB_HOST:$DB_PORT -timeout 30s
+
+./migrate
+
+exec "$@"


### PR DESCRIPTION
- Added `entrypoint.sh` script for allocating containers' running order/migrating db
- DB Migration will automatically start when Docker container is started to running